### PR TITLE
Shepherd shows Singularity icon for retina displays

### DIFF
--- a/os-icons/os-icons.css
+++ b/os-icons/os-icons.css
@@ -94,7 +94,7 @@
     .shepherd-icon {
         background-image: url("shepherd-icon@2x.png");
     }
-    .shepherd-icon {
+    .singularity-icon {
         background-image: url("singularity-icon@2x.png");
     }
 }


### PR DESCRIPTION
In the retina display media-query CSS, there is a typo that declares
the `.shepherd-icon` icon twice instead of `.shepherd-icon` and
`.singularity-icon` once each. This has the effect of the Shepherd
entry showing the same icon as Singularity for these devices.

See attached image:
![hubspot-os-bug](https://cloud.githubusercontent.com/assets/30241/5673281/778b6f94-9767-11e4-85bf-2e3df6a0a2ed.png)
