### PR TITLE
Use a cached JSONP file (built via internal tool) instead of always fetching from the github API.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.sass-cache
 *.scssc
 *.DS_Store
+_site/

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
         <script type="text/javascript" src="assets/widearea.min.js"></script>
         <script type="text/javascript" src="assets/strftime.js"></script>
         <script type="text/javascript" src="app.js"></script>
+        <script type="text/javascript" src="http://static.hsappstatic.net/hubspotdev-github-data-cache/ex/hubspot-filtered-org-data.json"></script>
     </head>
     <body>
 


### PR DESCRIPTION
Looked good when I ran `jekyll serve` locally.

/cc @graysky